### PR TITLE
Tune gpu memory usage

### DIFF
--- a/bigwig_loader/bigwig.py
+++ b/bigwig_loader/bigwig.py
@@ -163,7 +163,7 @@ class BigWig:
             memory_bank = MemoryBank(elastic=True)
         if decoder is None:
             decoder = Decoder(
-                max_num_chunks=10000 * 100,  # 512 * len(self.bigwigs) * 10,
+                max_num_chunks=0,  # the decoder can elastically increase
                 max_rows_per_chunk=self.max_rows_per_chunk,
                 max_uncompressed_chunk_size=self.max_rows_per_chunk * 12 + 24,
                 chromosome_offsets=None,

--- a/bigwig_loader/bigwig.py
+++ b/bigwig_loader/bigwig.py
@@ -163,7 +163,6 @@ class BigWig:
             memory_bank = MemoryBank(elastic=True)
         if decoder is None:
             decoder = Decoder(
-                max_num_chunks=0,  # the decoder can elastically increase
                 max_rows_per_chunk=self.max_rows_per_chunk,
                 max_uncompressed_chunk_size=self.max_rows_per_chunk * 12 + 24,
                 chromosome_offsets=None,

--- a/bigwig_loader/collection.py
+++ b/bigwig_loader/collection.py
@@ -58,7 +58,7 @@ class BigWigCollection:
         self.pinned_memory_size = pinned_memory_size
         self._memory_bank: Optional[MemoryBank] = None
         self._decoder = Decoder(
-            max_num_chunks=10000 * 100,  # 512 * len(self.bigwigs) * 10,
+            max_num_chunks=0,
             max_rows_per_chunk=max_rows_per_chunk,
             max_uncompressed_chunk_size=max_rows_per_chunk * 12 + 24,
             chromosome_offsets=self.local_chrom_ids_to_offset_matrix,
@@ -132,6 +132,13 @@ class BigWigCollection:
         gpu_byte_array, comp_chunks, compressed_chunk_sizes = memory_bank.to_gpu()
         _, start, end, value, n_rows_for_chunks = self._decoder.decode(
             gpu_byte_array, comp_chunks, compressed_chunk_sizes, bigwig_ids=bigwig_ids
+        )
+
+        logging.debug(
+            f"decompressed array sizes {len(start), len(end), len(value), len(n_rows_for_chunks), len(bigwig_ids)}"
+        )
+        logging.debug(
+            f"Cupy default memory pool:{ cp.get_default_memory_pool().used_bytes() / 1024} kB"
         )
 
         chunk_row_numbers = cp.pad(cp.cumsum(n_rows_for_chunks), (1, 0))

--- a/bigwig_loader/collection.py
+++ b/bigwig_loader/collection.py
@@ -58,7 +58,6 @@ class BigWigCollection:
         self.pinned_memory_size = pinned_memory_size
         self._memory_bank: Optional[MemoryBank] = None
         self._decoder = Decoder(
-            max_num_chunks=0,
             max_rows_per_chunk=max_rows_per_chunk,
             max_uncompressed_chunk_size=max_rows_per_chunk * 12 + 24,
             chromosome_offsets=self.local_chrom_ids_to_offset_matrix,

--- a/bigwig_loader/dataset.py
+++ b/bigwig_loader/dataset.py
@@ -49,7 +49,7 @@ class BigWigDataset:
         first_n_files: Only use the first n files (handy for debugging on less tasks)
         position_sampler_buffer_size: number of intervals picked up front by the position sampler.
             When all intervals are used, new intervals are picked.
-        repeat_same_positions: if False the positions sampler does not draw a new random collection
+        repeat_same_positions: if True the positions sampler does not draw a new random collection
             of positions when the buffer runs out, but repeats the same samples. Can be used to
             check whether network can overfit.
 
@@ -175,7 +175,7 @@ class BigWigSuperDataset:
         first_n_files: Only use the first n files (handy for debugging on less tasks)
         position_sampler_buffer_size: number of intervals picked up front by the position sampler.
             When all intervals are used, new intervals are picked.
-        repeat_same_positions: if False the positions sampler does not draw a new random collection
+        repeat_same_positions: if True the positions sampler does not draw a new random collection
             of positions when the buffer runs out, but repeats the same samples. Can be used to
             check whether network can overfit.
 

--- a/bigwig_loader/gpu_decompressor.py
+++ b/bigwig_loader/gpu_decompressor.py
@@ -33,7 +33,7 @@ class Decoder:
         self.max_rows_per_chunk = max_rows_per_chunk
 
         self.uncomp_chunks: list[cp.ndarray] = []
-        self.uncomp_chunk_ptrs: cp.ndarray = None  # cp.array([], dtype=cp.uint64)
+        self.uncomp_chunk_ptrs: cp.ndarray = None
         self.uncomp_chunk_sizes: cp.ndarray = None
         self.actual_uncomp_chunk_sizes: cp.ndarray = None
         self.statuses: cp.ndarray = None

--- a/bigwig_loader/gpu_decompressor.py
+++ b/bigwig_loader/gpu_decompressor.py
@@ -21,14 +21,13 @@ class Decoder:
 
     def __init__(
         self,
-        max_num_chunks: int,
         max_rows_per_chunk: int,
         max_uncompressed_chunk_size: int = (2048 * 12),
         chromosome_offsets: Optional[
             Union[Sequence[int], npt.NDArray[np.int64]]
         ] = None,
     ):
-        self.max_num_chunks = max_num_chunks
+        self.max_num_chunks = 0
         self.max_uncompressed_chunk_size = max_uncompressed_chunk_size
         self.max_rows_per_chunk = max_rows_per_chunk
 
@@ -37,8 +36,6 @@ class Decoder:
         self.uncomp_chunk_sizes: cp.ndarray = None
         self.actual_uncomp_chunk_sizes: cp.ndarray = None
         self.statuses: cp.ndarray = None
-
-        self.reserve_memory(max_num_chunks)
 
         self.range_of_indexes = cp.arange(max_rows_per_chunk)
         if chromosome_offsets is not None:

--- a/bigwig_loader/gpu_decompressor.py
+++ b/bigwig_loader/gpu_decompressor.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 from typing import Sequence
 from typing import Union
@@ -6,7 +7,6 @@ import cupy as cp
 import numcodecs
 import numpy as np
 import numpy.typing as npt
-from numcodecs.compat import ensure_contiguous_ndarray_like
 
 codec = numcodecs.registry.get_codec(
     {
@@ -28,27 +28,48 @@ class Decoder:
             Union[Sequence[int], npt.NDArray[np.int64]]
         ] = None,
     ):
+        self.max_num_chunks = max_num_chunks
         self.max_uncompressed_chunk_size = max_uncompressed_chunk_size
-
-        self.uncomp_chunks = [
-            cp.empty(max_uncompressed_chunk_size, dtype=cp.uint8)
-            for _ in range(max_num_chunks)
-        ]
-        self.uncomp_chunk_ptrs = cp.array(
-            [c.data.ptr for c in self.uncomp_chunks], dtype=cp.uint64
-        )
-        self.uncomp_chunk_sizes = cp.array(
-            [max_uncompressed_chunk_size] * max_num_chunks, dtype=cp.uint64
-        )
-        self.actual_uncomp_chunk_sizes = cp.empty(max_num_chunks, dtype=cp.uint64)
-        self.statuses = cp.empty(max_num_chunks, dtype=cp.int32)
         self.max_rows_per_chunk = max_rows_per_chunk
+
+        self.uncomp_chunks: list[cp.ndarray] = []
+        self.uncomp_chunk_ptrs: cp.ndarray = None  # cp.array([], dtype=cp.uint64)
+        self.uncomp_chunk_sizes: cp.ndarray = None
+        self.actual_uncomp_chunk_sizes: cp.ndarray = None
+        self.statuses: cp.ndarray = None
+
+        self.reserve_memory(max_num_chunks)
 
         self.range_of_indexes = cp.arange(max_rows_per_chunk)
         if chromosome_offsets is not None:
             self.chromosome_offsets = cp.asarray(chromosome_offsets, dtype="uint32")
         else:
             self.chromosome_offsets = None
+
+    def reserve_memory(self, num_chunks: int, generocity: float = 1.2) -> None:
+        """Create arrays to hold the uncompressed chunks."""
+
+        if num_chunks <= self.max_num_chunks:
+            return
+
+        num_chunks = int(num_chunks * generocity)
+
+        logging.debug(f"Reserving memory for {num_chunks} chunks")
+
+        self.uncomp_chunks = [
+            cp.empty(self.max_uncompressed_chunk_size, dtype=cp.uint8)
+            for _ in range(num_chunks)
+        ]
+        self.uncomp_chunk_ptrs = cp.array(
+            [c.data.ptr for c in self.uncomp_chunks], dtype=cp.uint64
+        )
+        self.uncomp_chunk_sizes = cp.array(
+            [self.max_uncompressed_chunk_size] * num_chunks, dtype=cp.uint64
+        )
+        self.actual_uncomp_chunk_sizes = cp.empty(num_chunks, dtype=cp.uint64)
+        self.statuses = cp.empty(num_chunks, dtype=cp.int32)
+
+        self.max_num_chunks = num_chunks
 
     def decode(
         self,
@@ -58,6 +79,8 @@ class Decoder:
         bigwig_ids: Optional[cp.ndarray] = None,
     ) -> tuple[cp.ndarray, cp.ndarray, cp.ndarray, cp.ndarray, cp.ndarray]:
         num_chunks = len(comp_chunks)
+
+        self.reserve_memory(num_chunks)
 
         max_chunk_size = int(self.max_uncompressed_chunk_size)
 

--- a/bigwig_loader/memory_bank.py
+++ b/bigwig_loader/memory_bank.py
@@ -58,9 +58,6 @@ class MemoryBank:
             offset: byte offset to start of compressed chunk
             size: byte size of compressed chunk
             skip_bytes: skips this number of bytes from offset
-            increase_memory_size: whether to elastically increase the
-                size of the pinned memory if the new chunk doesn't
-                fit in anymore. (default: True)
         Returns:
 
         """


### PR DESCRIPTION
The memory needed for the decompressor was all reserved up front. A large value was set to make sure it was large enough. This led to an unnecessarily high GPU memory consumption. Now the memory is increased dynamically.