### PR TITLE
Feature/reduce startup

### DIFF
--- a/bigwig_loader/bigwig.py
+++ b/bigwig_loader/bigwig.py
@@ -400,7 +400,7 @@ class BigWig:
         return mapping  # type: ignore
 
     def _guess_max_rows_per_chunk(
-        self, file_object: BinaryIO, sample_size: int = 300
+        self, file_object: BinaryIO, sample_size: int = 100
     ) -> int:
         """
         Randomly samples some chunks and looks in the header

--- a/bigwig_loader/intervals_to_values_gpu.py
+++ b/bigwig_loader/intervals_to_values_gpu.py
@@ -1,4 +1,5 @@
 import logging
+import math
 
 import cupy as cp
 
@@ -203,7 +204,7 @@ def intervals_to_values(
 
 
 def get_grid_and_block_size(n_threads: int) -> tuple[int, int]:
-    n_blocks_needed = cp.ceil(n_threads / 512).astype(dtype=cp.int32).item()
+    n_blocks_needed = math.ceil(n_threads / 512)
     if n_blocks_needed == 1:
         threads_per_block = n_threads
     else:

--- a/bigwig_loader/memory_bank.py
+++ b/bigwig_loader/memory_bank.py
@@ -61,6 +61,10 @@ class MemoryBank:
         Returns:
 
         """
+        # cast this to python int because when it's uint64 and we add/subtract
+        # skip_bytes, it somehow becomes float64, which we don't want.
+        offset = int(offset)
+        size = int(size)
         offset += skip_bytes
         size -= skip_bytes
         if file_handle is not self._current_file_handle:

--- a/bigwig_loader/parser.py
+++ b/bigwig_loader/parser.py
@@ -347,7 +347,7 @@ class RTreeNode:
                     end_base=end_base,
                     offset=data_offset,
                 )
-            children.append(child_node)
+                children.append(child_node)
 
         return cls(
             is_leaf=False,

--- a/bigwig_loader/parser.py
+++ b/bigwig_loader/parser.py
@@ -305,9 +305,8 @@ class RTreeNode:
 
         children = []
         position = file_object.tell()
-        for i in range(count):
-            file_object.seek(position)
-            if is_leaf:
+        if is_leaf:
+            for i in range(count):
                 (
                     start_chrom_ix,
                     start_base,
@@ -316,8 +315,6 @@ class RTreeNode:
                     data_offset,
                     data_size,
                 ) = struct.unpack("<LLLLQQ", file_object.read(32))
-                position = file_object.tell()
-
                 child_node = RTreeNode(
                     is_leaf=True,
                     children=[],
@@ -328,7 +325,11 @@ class RTreeNode:
                     data_offset=data_offset,
                     data_size=data_size,
                 )
-            else:
+                children.append(child_node)
+
+        else:
+            for i in range(count):
+                file_object.seek(position)
                 (
                     start_chrom_ix,
                     start_base,


### PR DESCRIPTION
This speeds up the initial parsing of the bigwig files. This only happens in the beginning and does not affect the actual data loading during batch generation for training. Still, when have a lot of files it is annoying to have such a long startup time.