### PR TITLE
Adding feature to use custom "default_value" as filler for intervals …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
-...
+### Added
+- set a default value different from 0.0
 
 ## [v0.1.4]
 ### Fixed
@@ -44,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - release to pypi
 
 [Unreleased]: https://github.com/pfizer-opensource/bigwig-loader/compare/v0.1.4...HEAD
-[v0.1.3]: https://github.com/pfizer-opensource/bigwig-loader/compare/v0.1.4...v0.1.4
+[v0.1.4]: https://github.com/pfizer-opensource/bigwig-loader/compare/v0.1.3...v0.1.4
 [v0.1.3]: https://github.com/pfizer-opensource/bigwig-loader/compare/v0.1.2...v0.1.3
 [v0.1.2]: https://github.com/pfizer-opensource/bigwig-loader/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/pfizer-opensource/bigwig-loader/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+...
+
+## [v0.1.5]
 ### Added
 - set a default value different from 0.0
 
@@ -44,7 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - release to pypi
 
-[Unreleased]: https://github.com/pfizer-opensource/bigwig-loader/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/pfizer-opensource/bigwig-loader/compare/v0.1.5...HEAD
+[v0.1.5]: https://github.com/pfizer-opensource/bigwig-loader/compare/v0.1.4...v0.1.5
 [v0.1.4]: https://github.com/pfizer-opensource/bigwig-loader/compare/v0.1.3...v0.1.4
 [v0.1.3]: https://github.com/pfizer-opensource/bigwig-loader/compare/v0.1.2...v0.1.3
 [v0.1.2]: https://github.com/pfizer-opensource/bigwig-loader/compare/v0.1.1...v0.1.2

--- a/bigwig_loader/batch_processor.py
+++ b/bigwig_loader/batch_processor.py
@@ -104,6 +104,7 @@ class BatchProcessor:
         end: Union[Sequence[int], npt.NDArray[np.int64]],
         window_size: int = 1,
         scaling_factors_cupy: Optional[cp.ndarray] = None,
+        default_value: float = 0.0,
         out: Optional[cp.ndarray] = None,
     ) -> cp.ndarray:
         (
@@ -137,10 +138,10 @@ class BatchProcessor:
             query_starts=abs_start,
             query_ends=abs_end,
             window_size=window_size,
+            default_value=default_value,
             out=out,
         )
         batch = cp.transpose(out, (1, 0, 2))
         if scaling_factors_cupy is not None:
             batch *= scaling_factors_cupy
-
         return batch

--- a/bigwig_loader/collection.py
+++ b/bigwig_loader/collection.py
@@ -140,6 +140,7 @@ class BigWigCollection:
         start: Union[Sequence[int], npt.NDArray[np.int64]],
         end: Union[Sequence[int], npt.NDArray[np.int64]],
         window_size: int = 1,
+        default_value: float = 0.0,
         out: Optional[cp.ndarray] = None,
     ) -> cp.ndarray:
         return self.batch_processor.get_batch(
@@ -148,6 +149,7 @@ class BigWigCollection:
             end=end,
             window_size=window_size,
             scaling_factors_cupy=self.scaling_factors_cupy,
+            default_value=default_value,
             out=out,
         )
 

--- a/bigwig_loader/collection.py
+++ b/bigwig_loader/collection.py
@@ -173,7 +173,8 @@ class BigWigCollection:
 
         """
         offsets = np.array(
-            [self.chromosome_offset_dict[chrom] for chrom in chromosomes]
+            [self.chromosome_offset_dict[chrom] for chrom in chromosomes],
+            dtype=np.int64,
         )
         return positions + offsets
 

--- a/bigwig_loader/streamed_dataset.py
+++ b/bigwig_loader/streamed_dataset.py
@@ -108,6 +108,7 @@ class StreamedDataloader:
         queue_size: int = 10,
         slice_size: int | None = None,
         window_size: int = 1,
+        default_value: float = 0.0,
     ):
         self.input_generator = input_generator
         self.collection = collection
@@ -127,6 +128,7 @@ class StreamedDataloader:
         self.data_generator_thread: threading.Thread | None = None
         self._entered = False
         self._out = None
+        self._default_value = default_value
 
     def __enter__(self) -> "StreamedDataloader":
         self._entered = True
@@ -214,6 +216,7 @@ class StreamedDataloader:
                             found_starts=found_starts[:, select],
                             found_ends=found_ends[:, select],
                             window_size=self.window_size,
+                            default_value=self._default_value,
                             out=out,
                         )
 
@@ -248,7 +251,7 @@ class StreamedDataloader:
         shape = (number_of_tracks, batch_size, sequence_length)
 
         if self._out is None or self._out.shape != shape:
-            self._out = cp.zeros(shape, dtype=cp.float32)
+            self._out = cp.full(shape, self._default_value, dtype=cp.float32)
         return self._out
 
     def _determine_slice_size(self, n_samples: int) -> int:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -57,6 +57,29 @@ def test_get_batch(collection):
     assert batch.shape == (256, n_files, 1000)
 
 
+def test_get_batch_with_nans(collection):
+    """
+    Testing whether NaNs are returned when setting
+    the default_value to cp.nan. Giving it some
+    coordinates way beyond the total chromosome
+    length now because the bigwigs I am testing
+    on include intervals with value 0.0 instead
+    of just not listing it.
+    """
+    n_files = len(collection.bigwig_paths)
+
+    batch = collection.get_batch(
+        ["chr1", "chr20", "chr4"],
+        [0, 99998999, 99998999],
+        [1000, 99999999, 99999999],
+        default_value=cp.nan,
+    )
+
+    print(batch)
+    assert batch.shape == (3, n_files, 1000)
+    assert cp.any(cp.isnan(batch))
+
+
 def test_exclude_intervals(collection):
     intervals = collection.intervals(
         ["chr3", "chr4", "chr5"], exclude_chromosomes=["chr4"]

--- a/tests/test_intervals_to_values.py
+++ b/tests/test_intervals_to_values.py
@@ -230,3 +230,34 @@ def test_get_values_from_intervals_batch_multiple_tracks() -> None:
     print(expected)
     print(values)
     assert (values == expected).all()
+
+
+def test_default_nan() -> None:
+    """Query end is exactly at end index before "gap"
+       Now instead of zeros, NaN values should be
+       used.
+    ."""
+    track_starts = cp.asarray([5, 10, 12, 18], dtype=cp.int32)
+    track_ends = cp.asarray([10, 12, 14, 20], dtype=cp.int32)
+    track_values = cp.asarray([20.0, 30.0, 40.0, 50.0], dtype=cp.dtype("f4"))
+    query_starts = cp.asarray([7, 9], dtype=cp.int32)
+    query_ends = cp.asarray([18, 20], dtype=cp.int32)
+    reserved = cp.zeros([2, 11], dtype=cp.dtype("<f4"))
+    values = intervals_to_values(
+        track_starts,
+        track_ends,
+        track_values,
+        query_starts,
+        query_ends,
+        default_value=cp.nan,
+        out=reserved,
+    )
+    expected = cp.asarray(
+        [
+            [20.0, 20.0, 20.0, 30.0, 30.0, 40.0, 40.0, cp.nan, cp.nan, cp.nan, cp.nan],
+            [20.0, 30.0, 30.0, 40.0, 40.0, cp.nan, cp.nan, cp.nan, cp.nan, 50.0, 50.0],
+        ]
+    )
+    print(expected)
+    print(values)
+    assert cp.allclose(values, expected, equal_nan=True)


### PR DESCRIPTION
…that are not included in the bigwig files. The default is 0.0, which is consistent with the previous behavior. Now any custom value may be used, like cp.nan.