### PR TITLE
Updated conda environment.yml with upper bound to kvikio.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip
   - cython
   - c-compiler
-  - kvikio>=24.06.00
+  - kvikio>=24.06.00,<=25.08.00
   - cupy>=12.0.0
   - numpy>=1.21
   - pandas


### PR DESCRIPTION
NVIDIA removed nvcomp from kvikio to put it (closed source) inside nvidia.nvcomp. kvikio 25.08.00 is the last version that has nvcomp (https://github.com/rapidsai/kvikio/releases/tag/v25.10.00)